### PR TITLE
Restrict `radix` usage to its base module so that it doesn't affect Ruby's `String.b`

### DIFF
--- a/lib/spider-gazelle/app_store.rb
+++ b/lib/spider-gazelle/app_store.rb
@@ -1,5 +1,5 @@
 require 'thread'
-require 'radix'
+require 'radix/base'
 
 
 module SpiderGazelle


### PR DESCRIPTION
Hi,

Great work with `spider-gazelle`! I'm trying it out and it already feels amazing!

Here's a simple patch to restrict `radix` usage to its base module so that it doesn't affect Ruby's `String.b`.

Spider-Gazelle's usage of radix doesn't need the whole gem required and the current approach is an issue with at least [MRI's ERB](https://github.com/ruby/ruby/blob/trunk/lib/erb.rb#L600).

BTW, quick question, how far are you planning on taking this implementation? Are you already using it in production somewhere?

Thanks,
Darío
