### PR TITLE
Always have a QUERY_STRING in the request

### DIFF
--- a/lib/spider-gazelle/request.rb
+++ b/lib/spider-gazelle/request.rb
@@ -99,6 +99,7 @@ module SpiderGazelle
             else
                 @env[PATH_INFO] = @url
                 @env[REQUEST_PATH] = @url
+                @env[QUERY_STRING] = ''
             end
 
             # Grab the host name from the request


### PR DESCRIPTION
Since Rack kind of promises that `QUERY_STRING` will be in its request and to play nice with frameworks expecting, it might be a good idea to have an empty `QUERY_STRING` in the request's environment.

[Padrino](https://github.com/padrino/padrino-framework/blob/8f20c89b018e209512350c369ed8b265b414c616/padrino-core/lib/padrino-core/logger.rb#L413)
[Rails](https://github.com/rails/rails/blob/e20dd73df42d63b206d221e2258cc6dc7b1e6068/actionpack/lib/action_dispatch/http/filter_parameters.rb#L47)

What do you think about it?

An alternative would be to modify the framework's implementations not to use `AS`'s `empty?` on something that might be `nil`. As a `Padrino` core developer, it's not a problem on our end at all :) although it will increase compatibility with other frameworks that are already depending on that.
