### PR TITLE
Set Rubinius to allow_failures in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,7 @@ rvm:
   - ruby-head
   - rbx-2
   - jruby-head
+matrix:
+  allow_failures:
+    - rvm: rbx-2
 sudo: false


### PR DESCRIPTION
Allow Rubinius to fail on Travis while we address the error presently occurring without disrupting the project.